### PR TITLE
Redo the flow of shutdown.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,12 +19,5 @@ script:
 after_success:
 - bash <(curl -s https://codecov.io/bash)
 
-after_success:
-- bash <(curl -s https://codecov.io/bash)
-
 go:
-- 1.6
-
-notifications:
-  slack:
-    secure: K9tsn5MvrCAxuEZTxn+m3Kq1K2NG2xMEJFSv/sTp+RQBW7TslPHzv859GsIvrm8mU1y1btOU9RlOzqrRUczI5cJpE8IL1oljPZbXrIXgetE0kbsw0Wpy99g27UQ2VGp933WDu8tfj7zU4cZv+BI0RltNLwqYO6GWXmcWP0IueCU=
+- 1.6.2

--- a/main.go
+++ b/main.go
@@ -158,9 +158,6 @@ func main() {
 		// Enable all loggers by now.
 		enableLoggers()
 
-		// Initialize name space lock.
-		initNSLock()
-
 		// Set global quiet flag.
 		globalQuiet = c.Bool("quiet") || c.GlobalBool("quiet")
 
@@ -188,9 +185,6 @@ func main() {
 	case "block":
 		defer profile.Start(profile.BlockProfile, profile.ProfilePath(profileDir)).Stop()
 	}
-
-	// Initialize and monitor shutdown signal
-	initGracefulShutdown(os.Exit)
 
 	// Run the app - exit on error.
 	app.RunAndExitOnError()

--- a/object-interface.go
+++ b/object-interface.go
@@ -21,6 +21,7 @@ import "io"
 // ObjectLayer implements primitives for object API layer.
 type ObjectLayer interface {
 	// Storage operations.
+	Shutdown() error
 	StorageInfo() StorageInfo
 
 	// Bucket operations.

--- a/server-main.go
+++ b/server-main.go
@@ -259,7 +259,8 @@ func serverMain(c *cli.Context) {
 	// Prints the formatted startup message.
 	printStartupMessage(endPoints)
 
-	registerShutdown(func() errCode {
+	// Register generic callbacks.
+	globalShutdownCBs.AddGenericCB(func() errCode {
 		// apiServer.Stop()
 		return exitSuccess
 	})

--- a/test-utils_test.go
+++ b/test-utils_test.go
@@ -744,15 +744,6 @@ type objTestDiskNotFoundType func(obj ObjectLayer, instanceType string, dirs []s
 // ExecObjectLayerTest - executes object layer tests.
 // Creates single node and XL ObjectLayer instance and runs test for both the layers.
 func ExecObjectLayerTest(t TestErrHandler, objTest objTestType) {
-	// Object layers define graceful shutdown functions, so we need to prepare
-	// the shutdown mechanism first
-	dummySuccess := func(code int) {
-		if code != int(exitSuccess) {
-			t.Fatalf("Expected %d, got %d instead.", code, exitSuccess)
-		}
-	}
-	initGracefulShutdown(dummySuccess)
-
 	objLayer, fsDir, err := getSingleNodeObjectLayer()
 	if err != nil {
 		t.Fatalf("Initialization of object layer failed for single node setup: %s", err)

--- a/utils_test.go
+++ b/utils_test.go
@@ -28,12 +28,11 @@ func TestShutdownCallbackSuccess(t *testing.T) {
 	}
 	initGracefulShutdown(dummySuccess)
 	// Register two callbacks that return success
-	registerObjectStorageShutdown(func() errCode {
+	globalShutdownCBs.AddObjectLayerCB(func() errCode {
 		return exitSuccess
 	})
-	registerShutdown(func() errCode {
+	globalShutdownCBs.AddGenericCB(func() errCode {
 		return exitSuccess
 	})
-
-	shutdownSignal <- true
+	globalShutdownSignalCh <- struct{}{}
 }

--- a/xl-v1.go
+++ b/xl-v1.go
@@ -206,6 +206,12 @@ func newXLObjects(disks, ignoredDisks []string) (ObjectLayer, error) {
 	return xl, nil
 }
 
+// Shutdown function for object storage interface.
+func (xl xlObjects) Shutdown() error {
+	// Add any object layer shutdown activities here.
+	return nil
+}
+
 // byDiskTotal is a collection satisfying sort.Interface.
 type byDiskTotal []disk.Info
 


### PR DESCRIPTION
Introduce a new API on object storage called as Shutdown() which
is implemented per object layer which makes this cleaner.

The reasoning is that registering of callbacks should be done
in a common place and not inside object later initialization.
